### PR TITLE
Fix threads scraping

### DIFF
--- a/base_interface.py
+++ b/base_interface.py
@@ -47,7 +47,7 @@ class BaseThreadsInterface:
             The user's unique identifier as an integer.
         """
         response = requests.get(
-            url=f'https://www.instagram.com/{username}',
+            url=f'https://www.threads.net/@{username}',
             headers=self.headers_for_html_fetching,
         )
 
@@ -74,3 +74,14 @@ class BaseThreadsInterface:
             thread_id = (thread_id * 64) + alphabet.index(character)
 
         return thread_id
+
+    def build_url_id(self, thread_id: int) -> str:
+        """Generate the base64-like URL id for a thread."""
+        alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'
+        if thread_id == 0:
+            return alphabet[0]
+        chars = []
+        while thread_id > 0:
+            thread_id, idx = divmod(thread_id, 64)
+            chars.append(alphabet[idx])
+        return ''.join(reversed(chars))


### PR DESCRIPTION
## Summary
- generate API token and user IDs via threads.net instead of Instagram
- add helper to convert thread ID to URL ID
- rewrite thread fetcher to scrape thread page

## Testing
- `python -m py_compile base_interface.py threads_interface.py`
- `python - <<'PY'
from threads_interface import ThreadsInterface
iface = ThreadsInterface()
uid = iface.retrieve_user_id('instagram')
threads = iface.retrieve_user_threads(uid)
print('num threads', len(threads['data']['mediaData']['threads']))
post_id = threads['data']['mediaData']['threads'][0]['thread_items'][0]['post']['pk']
thread = iface.retrieve_thread(int(post_id))
print('thread', thread)
PY`

------
https://chatgpt.com/codex/tasks/task_e_688a292158c0832c92189250b6acaf7e